### PR TITLE
Remove needless eval-when-compile

### DIFF
--- a/evil-vimish-fold.el
+++ b/evil-vimish-fold.el
@@ -35,8 +35,7 @@
 
 (require 'evil)
 (require 'vimish-fold)
-(eval-when-compile
-  '(require 'cl-lib))
+(require 'cl-lib)
 
 (evil-define-operator evil-vimish-fold/create (beg end)
   "Create a fold from the current region.


### PR DESCRIPTION
Because this package uses cl-lib function.

And original code makes no sense because it has needless quote and it evaluates as `(require (quote cl-lib))`.

